### PR TITLE
Fixing timezone string, browser location/history, person map height, copyright year, and mobile enhancements

### DIFF
--- a/src/js/components/Finder.js
+++ b/src/js/components/Finder.js
@@ -47,12 +47,9 @@ export default class Finder extends Component {
       colorIndex = "neutral-1-a";
       footer = (
         <Footer float={true} colorIndex="grey-3-a"
-          pad={{vertical: "small", horizontal: "medium"}}>
+          pad={{vertical: "small", horizontal: "medium", between: "medium"}} wrap={true} direction="row" justify="between">
           <img src="img/hpesm_pri_grn_rev_rgb.svg" alt="logo" className="logo" />
-          <Box className="flex" align="end">
-            <Paragraph size="small">© Copyright
-              2015 Hewlett Packard Enterprise Development LP</Paragraph>
-          </Box>
+          <Paragraph size="small">{`\u00a9 ${new Date().getFullYear()}  Hewlett Packard Enterprise Development LP`}</Paragraph>
         </Footer>
       );
     }
@@ -71,18 +68,22 @@ export default class Finder extends Component {
         <Header key="header" large={true}
           pad={{horizontal: "medium", between: "small"}}
           float={this.props.initial}
-          colorIndex={colorIndex} splash={this.props.initial} responsive={false}>
+          colorIndex={colorIndex} splash={this.props.initial} 
+          responsive={false} justify="between">
           <Title>
             <Logo reverse={true} />
             {title}
           </Title>
-          <Search ref="search" inline={true} className="flex"
-            placeHolder="Search"
-            defaultValue={this.props.searchText}
-            onChange={this.props.onSearch} />
-          <Menu inline={false} dropColorIndex={colorIndex} dropAlign={{right: "right"}}>
-            {scopeAnchors}
-          </Menu>
+          <Box className="flex" direction="row" responsive={false}
+            align="center" justify="end">
+            <Search ref="search" inline={true} className="flex"
+              placeHolder="Search"
+              defaultValue={this.props.searchText}
+              onChange={this.props.onSearch} />
+            <Menu inline={false} dropColorIndex={colorIndex} dropAlign={{right: "right"}}>
+              {scopeAnchors}
+            </Menu>
+          </Box>
         </Header>
         {this.props.children}
         {footer}

--- a/src/js/components/PeopleFinder.js
+++ b/src/js/components/PeopleFinder.js
@@ -19,9 +19,10 @@ export default class PeopleFinder extends Component {
 
   constructor () {
     super();
+    this._popState = this._popState.bind(this);
     this._onSearchText = this._onSearchText.bind(this);
-    this._onSelect = this._onSelect.bind(this);
     this._onScope = this._onScope.bind(this);
+    this._onSelect = this._onSelect.bind(this);
     this._onCloseItem = this._onCloseItem.bind(this);
     this.state = { searchText: '', scope: config.scopes.people, initial: true };
   }

--- a/src/js/components/Person.js
+++ b/src/js/components/Person.js
@@ -2,12 +2,14 @@
 
 import React, { Component, PropTypes } from 'react';
 import { FormattedMessage } from 'react-intl';
+import Responsive from 'grommet/utils/Responsive';
 import Rest from 'grommet/utils/Rest';
 import Anchor from 'grommet/components/Anchor';
 import Article from 'grommet/components/Article';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Header from 'grommet/components/Header';
+import Heading from 'grommet/components/Heading';
 import Menu from 'grommet/components/Menu';
 import Paragraph from 'grommet/components/Paragraph';
 import Section from 'grommet/components/Section';
@@ -28,19 +30,23 @@ export default class Person extends Component {
 
   constructor () {
     super();
+    this._onResponsive = this._onResponsive.bind(this);
     this._onPersonResponse = this._onPersonResponse.bind(this);
     this._onDetails = this._onDetails.bind(this);
     this._onGroups = this._onGroups.bind(this);
     this._onOrganization = this._onOrganization.bind(this);
+    this._onContact = this._onContact.bind(this);
     this._onLocationResponse = this._onLocationResponse.bind(this);
     this.state = {
       view: 'organization',
       person: {},
-      scope: config.scopes.people
+      scope: config.scopes.people,
+      responsive: false
     };
   }
 
   componentDidMount () {
+    this._responsive = Responsive.start(this._onResponsive);
     this._getPerson(this.props.id);
   }
 
@@ -50,15 +56,36 @@ export default class Person extends Component {
     }
   }
 
+  componentWillUnmount () {
+    this._responsive.stop();
+  }
+
+  _onResponsive (responsive) {
+    // check for view (sidebar) state, and make sure view is not
+    // set to 'contact' on larger sizes
+    let view = this.state.view;
+    if (! responsive && ('contact' === view)) {
+      view = 'organization';
+    } else if (responsive) {
+      view = 'contact';
+    }
+    this.setState({responsive: responsive, view: view});
+  }
+
   _onPersonResponse (err, res) {
     if (err) {
       this.setState({person: {}, error: err});
     } else if (res.ok) {
       const result = res.body;
       const person = result[0];
+      let view = this.state.view;
+
+      if (this.state.responsive) {
+        view = 'contact';
+      }
 
       this._getLocation(person.hpWorkLocation);
-      this.setState({person: person, error: null});
+      this.setState({person: person, error: null, view: view});
     }
   }
 
@@ -100,6 +127,11 @@ export default class Person extends Component {
 
   _onOrganization () {
     this.setState({view: 'organization'});
+  }
+
+  _onContact () {
+    // allow sidebar content to be set to 'contact' view for mobile
+    this.setState({view: 'contact'});
   }
 
   _formatHourInCity (hour, city, timezone) {
@@ -164,7 +196,7 @@ export default class Person extends Component {
       // could not find latitude + longitude, or timeZone
       // properties from LDAP location query
       currentPersonTime = 'No timezone information found.';
-      
+
       if (location.timeZone) {
         // fallback to using timeZone data from LDAP server
         // (which might not be taking DST into account)
@@ -185,6 +217,63 @@ export default class Person extends Component {
     );
     const person = this.state.person;
 
+    let personTitle;
+    if (person.title) {
+      personTitle = person.title.replace(/&amp;/g, '&');
+    }
+
+    let header;
+    if ('contact' !== this.state.view) {
+      header = (
+        <Header large={true} pad={{horizontal: "medium"}} separator="bottom"
+          justify="between">
+          <Title onClick={this.props.onClose} responsive={false}>
+            <Logo />
+            {appTitle}
+          </Title>
+          <Button icon={<SearchIcon />} onClick={this.props.onClose} />
+        </Header>
+      );
+    }
+
+    let contact;
+    let boxDirection = "row";
+    let contactPad = "none";
+    let contactContentsPad = "medium";
+    let contactInfoPad = { vertical: "medium" };
+
+    if (this.state.responsive) {
+      boxDirection = "column";
+      contactPad = { vertical: "medium", between: "medium" };
+      contactContentsPad = { horizontal: "medium" };
+      contactInfoPad = "none";
+    }
+
+    contact = (
+      <Article>
+        {header}
+        <Box direction={boxDirection} pad={contactPad} align="start">
+          <Box pad={contactContentsPad}>
+            <img className="avatar" src={person.hpPictureURI || 'img/no-picture.png'} alt="picture" />
+          </Box>
+          <Section pad={contactContentsPad} className="flex">
+            <Header tag="h1">
+              <span>{person.cn}</span>
+            </Header>
+            <Paragraph margin="none">{personTitle}</Paragraph>
+            <Box pad={contactInfoPad}>
+              <h2><a href={"mailto:" + person.uid}>{person.uid}</a></h2>
+              <h3><a href={"tel:" + person.telephoneNumber}>{person.telephoneNumber}</a></h3>
+              <h3>{this.state.currentPersonTime}</h3>
+            </Box>
+          </Section>
+        </Box>
+        <Map title={person.o}
+          street={person.street} city={person.l} state={person.st}
+          postalCode={person.postalCode} country={person.co} />
+      </Article>
+    );
+
     let view;
     let viewLabel;
     if ('details' === this.state.view) {
@@ -196,48 +285,35 @@ export default class Person extends Component {
     } else if ('organization' === this.state.view) {
       view = <Organization person={person} onSelect={this.props.onSelect} />;
       viewLabel = <FormattedMessage id="Organization" defaultMessage="Organization" />;
+    } else if ('contact' === this.state.view) {
+      view = contact;
+      viewLabel = "Contact";
     }
 
-    let personTitle;
-    if (person.title) {
-      personTitle = person.title.replace(/&amp;/g, '&');
+    let contactAnchor;
+    let viewHeader = <Heading tag="h3">{viewLabel}</Heading>;
+    if (this.state.responsive) {
+      // on mobile, allow contact (main Person content) as a menu option
+      // and show logo with bolded viewLabel
+      contactAnchor = <Anchor className={this.state.view === 'contact' ? 'active' : undefined} onClick={this._onContact} label="Contact" />;
+      viewHeader = (
+        <Box direction="row" responsive={false} align="center" pad={{between: "small"}}>
+          <Title onClick={this.props.onClose} responsive={false}>
+            <Logo />
+          </Title>
+          <Heading tag="h3" strong={true}>{viewLabel}</Heading>
+        </Box>
+      );
     }
 
     return (
       <Split flex="both" separator={true}>
-        <Article>
-          <Header large={true} pad={{horizontal: "medium"}} separator="bottom"
-            justify="between">
-            <Title onClick={this.props.onClose} responsive={false}>
-              <Logo />
-              {appTitle}
-            </Title>
-            <Button icon={<SearchIcon />} onClick={this.props.onClose} />
-          </Header>
-          <Box direction="row" pad="none" align="start">
-            <Box pad="medium">
-              <img className="avatar" src={person.hpPictureURI || 'img/no-picture.png'} alt="picture" />
-            </Box>
-            <Section pad="medium" className="flex">
-              <Header tag="h1">
-                <span>{person.cn}</span>
-              </Header>
-              <Paragraph margin="none">{personTitle}</Paragraph>
-              <Box pad={{vertical: "medium"}}>
-                <h2><a href={"mailto:" + person.uid}>{person.uid}</a></h2>
-                <h3><a href={"tel:" + person.telephoneNumber}>{person.telephoneNumber}</a></h3>
-                <h3>{this.state.currentPersonTime}</h3>
-              </Box>
-            </Section>
-          </Box>
-          <Map title={person.o}
-            street={person.street} city={person.l} state={person.st}
-            postalCode={person.postalCode} country={person.co} />
-        </Article>
+        {contact}
         <Sidebar>
           <Header large={true} pad={{horizontal: "medium"}} justify="between" separator="bottom">
-            <h3>{viewLabel}</h3>
+            {viewHeader}
             <Menu label="Menu" dropAlign={{right: 'right'}}>
+              {contactAnchor}
               <Anchor className={this.state.view === 'organization' ? 'active' : undefined} onClick={this._onOrganization}>
                 <FormattedMessage id="Organization" defaultMessage="Organization" />
               </Anchor>

--- a/src/js/components/Person.js
+++ b/src/js/components/Person.js
@@ -160,20 +160,21 @@ export default class Person extends Component {
             this.setState({currentPersonTime: currentPersonTime, error: null});
           }
         });
-    } else if (location.timeZone) {
-      // fallback to using timeZone data from LDAP server
-      // (which might not be taking DST into account)
-      const personTimezone = location.timeZone;
-      const personHour = this._getHourFromLDAPTimezone(personTimezone);
-      // formatting timezone from LDAP
-      const formattedPersonTimezone = `${personTimezone.substr(0,3)}:${personTimezone.substr(3,2)}`;
-      currentPersonTime = this._formatHourInCity(personHour, person.l, formattedPersonTimezone);
-
-      this.setState({currentPersonTime: currentPersonTime});
     } else {
       // could not find latitude + longitude, or timeZone
       // properties from LDAP location query
       currentPersonTime = 'No timezone information found.';
+      
+      if (location.timeZone) {
+        // fallback to using timeZone data from LDAP server
+        // (which might not be taking DST into account)
+        const personTimezone = location.timeZone;
+        const personHour = this._getHourFromLDAPTimezone(personTimezone);
+        // formatting timezone from LDAP
+        const formattedPersonTimezone = `${personTimezone.substr(0,3)}:${personTimezone.substr(3,2)}`;
+        currentPersonTime = this._formatHourInCity(personHour, person.l, formattedPersonTimezone);
+      }
+
       this.setState({currentPersonTime: currentPersonTime});
     }
   }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,7 +4,7 @@
 
 #map {
   width: 100%;
-  height: calc(100vh - 412px);
+  height: calc(100vh - 420px);
 
   .leaflet-popup-content-wrapper {
     border-radius: $border-radius;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,7 +4,7 @@
 
 #map {
   width: 100%;
-  height: calc(100vh - 420px);
+  height: calc(100vh - 444px);
 
   .leaflet-popup-content-wrapper {
     border-radius: $border-radius;
@@ -15,4 +15,6 @@
 // and only down until size of small icons
 .avatar {
   min-width: 48px;
+  width: 100%;
+  max-width: 150px;
 }


### PR DESCRIPTION
Issue: https://github.com/grommet/grommet-hpe/issues/80
- adding fallbacks for when LDAP server response (location query) is missing latitude and longitude (for GeoNames API lookup), and timeZone (which might not be taking DST into account).
- fixing browser location/history so back/forward buttons work
- adjusting height of Person map so it doesn't create an extra scrollbar for most users on the main content
- mobile improvements:
  - padding between footer contents
  - aligning control icons right
  - fixing person avatar stretching
  - adding controls in Person view to switch between "contact" (main content) view and organization/details/groups
- fixing copyright year
