### PR TITLE
People Finder Improvements: updated filterForSearch and style tweaks

### DIFF
--- a/src/js/components/Map.js
+++ b/src/js/components/Map.js
@@ -25,6 +25,17 @@ export default class Map extends Component {
         zoom: 5
       };
       const map = Leaflet.map(mapElement, options);
+
+      // vertically centering map popup
+      if (!this._onPopupOpen) {
+        this._onPopupOpen = (event) => {
+          let px = map.project(event.popup._latlng);
+          px.y -= event.popup._container.clientHeight / 2;
+          map.panTo(map.unproject(px), {animate: true});
+        };
+        map.on('popupopen', this._onPopupOpen);
+      }
+
       this.setState({map: map});
     }
 
@@ -46,6 +57,13 @@ export default class Map extends Component {
         this._setMap();
       }
     });
+  }
+
+  componentWillUnmount () {
+    const map = this.state.map;
+    if (this._onPopupOpen) {
+      map.off('popupopen', this._onPopupOpen);
+    }
   }
 
   _setMap (mapSize) {

--- a/src/js/components/Person.js
+++ b/src/js/components/Person.js
@@ -250,9 +250,9 @@ export default class Person extends Component {
 
     let phone;
     if (! person.telephoneNumber || '+1' === person.telephoneNumber) {
-      phone = <span className="secondary">no phone #</span>;
+      phone = <span className="secondary">Phone number not available.</span>;
     } else {
-      phone = <a href={"tel:" + person.telephoneNumber}>{person.telephoneNumber}</a>;
+      phone = <Anchor href={"tel:" + person.telephoneNumber}>{person.telephoneNumber}</Anchor>;
     }
 
     let image;
@@ -279,7 +279,7 @@ export default class Person extends Component {
             </Heading>
             <Paragraph margin="none">{personTitle}</Paragraph>
             <Paragraph size="large" margin="small">
-              <a href={"mailto:" + person.uid}>{person.uid}</a>
+              <Anchor href={"mailto:" + person.uid}>{person.uid}</Anchor>
             </Paragraph>
             <Paragraph size="large" margin="small">
               {phone}

--- a/src/js/components/Person.js
+++ b/src/js/components/Person.js
@@ -284,7 +284,9 @@ export default class Person extends Component {
             <Paragraph size="large" margin="small">
               {phone}
             </Paragraph>
-            <h3>{this.state.currentPersonTime}</h3>
+            <Paragraph size="large" margin="small">
+              {this.state.currentPersonTime}
+            </Paragraph>
           </Section>
         </Box>
         <Map title={person.o} className="flex"

--- a/src/js/components/PersonGroups.js
+++ b/src/js/components/PersonGroups.js
@@ -71,8 +71,8 @@ export default class PersonGroups extends Component {
     if (busy) {
       items = <BusyListItem />;
     } else {
-      items = groups.map(item => (
-        <GroupListItem key={item.uid} item={item} direction="column"
+      items = groups.map((item, index) => (
+        <GroupListItem key={index} item={item} direction="column"
           onClick={this._onSelect.bind(this, item)} />
       ));
     }

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -17,8 +17,20 @@ export default {
         if (searchText.indexOf(",") !== -1) {
           searchText = searchText.replace(/(.+),\s*(.+)/, "$2 $1");
         }
+
+        // allow ldap query to search for first/given name and last/surname to account for
+        // common names with middle initials
+        let queryEnd = "*)))";
+        const splitName = searchText.split(' ');
+
+        if (splitName.length && splitName.length > 1) {
+          const firstName = splitName[0];
+          const lastName = splitName[splitName.length - 1];
+          queryEnd = "*)(&|(givenName=" + firstName + "*)(sn=" + lastName + "*))))";
+        }
+
         // only return Active employees
-        return "(&(hpStatus=Active)(|(cn=*" + searchText + "*)(uid=*" + searchText + "*)))";
+        return "(&(hpStatus=Active)(|(cn=*" + searchText + "*)(uid=*" + searchText + queryEnd;
       }
     },
 

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -22,15 +22,14 @@ export default {
         // common names with middle initials
         let queryEnd = "*)))";
         const splitName = searchText.split(' ');
-
         if (splitName.length && splitName.length > 1) {
           const firstName = splitName[0];
           const lastName = splitName[splitName.length - 1];
-          queryEnd = "*)(&|(givenName=" + firstName + "*)(sn=" + lastName + "*))))";
+          queryEnd = `*)(&|(givenName=${firstName}*)(sn=${lastName}*))))`;
         }
 
         // only return Active employees
-        return "(&(hpStatus=Active)(|(cn=*" + searchText + "*)(uid=*" + searchText + queryEnd;
+        return `(&(hpStatus=Active)(|(cn=*${searchText}*)(uid=*${searchText}${queryEnd}`;
       }
     },
 
@@ -41,7 +40,7 @@ export default {
       id: "cn",
       attributes: ["cn", "description"],
       filterForSearch: function (searchText) {
-        return "(cn=*" + searchText + "*)";
+        return `(cn=*${searchText}*)`;
       }
     },
 
@@ -53,7 +52,7 @@ export default {
       attributes: ["buildingName", "l", "hpRealEstateID"],
       filterForSearch: function (searchText) {
         searchText = searchText.replace(/\s+/g, "*");
-        return "(|(buildingName=*" + searchText + "*)(l=*" + searchText + "*))";
+        return `(|(buildingName=*${searchText}*)(l=*${searchText}*))`;
       }
     }
   }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -7,7 +7,8 @@
     border-radius: $border-radius;
   }
 
-  .leaflet-control-container {
+  .leaflet-control-container,
+  .leaflet-popup {
     a:not(.anchor) {
       text-decoration: none;
     }


### PR DESCRIPTION
**https://github.com/grommet/grommet-hpe/issues/80:**
updating config filterForSeach function to account for common names with middle initials (e.g. "Martin R Fink"), by searching for givenName and sn when there's at least 2 words in the search field.

**https://github.com/grommet/hpe-design/issues/42: 
Updates/validation:**
- [x] ~~2. Map location centering that takes into account the location bubble. Offset the v-height to accommodate the blob.~~ Map popup now vertically centered.
- [x] ~~6. Link styling for email and phone should be the same size. Do we need header for email, phone, timezone?~~ Updated timezone to use Paragraph component instead of h3 tag to be more consistent with email and phone spacing.
- [x] ~~7. I thought we got rid of the underline on link styling…Looks odd on the email and phone values.~~ Switching `<a>` to `<Anchor>` tags to remove link styling from email and phone numbers. Also removing link underline from close button in leaflet popup.
- [x] ~~8. H1 line-height is shifting text down further from top-margin. Do we need to fix our line height for Metric?~~ H1 is using Heading component, so margin is consistent with the other Paragraphs on Person page.
- [x] ~~9. Do we need to have a message for unavailable phone numbers? Look at Meg Whitman contact. Might be nice to say, "Phone number not available."~~ Switched text from "no phone #" to "Phone number not available" for Person entries with missing phone numbers.
- [x] Using person groups index as key to fix same key warning.
